### PR TITLE
[Code Review] - Fix for Direct Access and Refresh on Client-Side Routes

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,6 +35,12 @@ app.use(passport.session());
 app.use(express.static(path.join(__dirname, "front", "dist")));
 app.use("/api", router);
 
+/* All remaining requests return the React app, so it can handle routing
+app.get("*", (req, res) => {
+  res.sendFile(path.resolve(__dirname, "front", "dist", "index.html"));
+});
+*/
+
 (async () => {
   try {
     await connectToDB();


### PR DESCRIPTION
Good design and well implemented!

Discovered a routing issue with the deployed version of our React application, specifically regarding direct access and refresh on client-side routes (e.g., accessing /dashboard directly or refreshing the page at https://note-app-2-0.onrender.com/dashboard results in a 'Cannot GET /dashboard' error).

This is due to the server configuration, which needs to be optimized for client-side routing. In production, accessing any route other than the root URL doesn't serve the `index.html` file necessary for React Router to manage the application's routing.

The solution involves adjusting the server setup, ensuring that `index.html` is returned for all routing requests, allowing React Router to correctly handle different paths. For an Express.js server, this can be implemented with a catch-all route:

```javascript
// Add this catch-all route after defining all other routes
app.get('*', (req, res) => {
  res.sendFile(path.join(__dirname, '/path/to/your/index.html'));
});

// Replace '/path/to/your/index.html' with the actual path to your index.html file.
